### PR TITLE
register and handle hover event for headcol

### DIFF
--- a/typechart.html
+++ b/typechart.html
@@ -60,13 +60,20 @@
     <script>
         $(function() {
 
-    $("table").delegate('td','mouseover mouseleave', function(e) {
+    $(".right table").delegate('td','mouseover mouseleave', function(e) {
         if (e.type == 'mouseover') {
-          $(this).parent().addClass("hover");
-          $("colgroup").eq($(this).index()).addClass("hover");
+            $(this).parent().addClass("hover");
+            $("colgroup").eq($(this).index()).addClass("hover");
         } else {
-          $(this).parent().removeClass("hover");
-          $("colgroup").eq($(this).index()).removeClass("hover");
+            $(this).parent().removeClass("hover");
+            $("colgroup").eq($(this).index()).removeClass("hover");
+        }
+    });
+    $(".headcol table").delegate('tr', 'mouseover mouseleave', function(e) {
+        if (e.type == 'mouseover') {
+            $(".right tr").eq($(this).index()).addClass("hover");
+        } else {
+            $(".right tr").eq($(this).index()).removeClass("hover");
         }
     });
 


### PR DESCRIPTION
Currently when the hovering doesn't work well for the .headcol table. When the user is hovering over the 'rock' in the head column:
current:
![image](https://cloud.githubusercontent.com/assets/6064797/17977104/e5a00932-6b22-11e6-885e-33abd7f40e71.png)
fixed:
![image](https://cloud.githubusercontent.com/assets/6064797/17977110/ed8e0cca-6b22-11e6-9a59-457f32739adb.png)
